### PR TITLE
Feat: 게시글에 댓글 목록과 좋아요 숫자를 보이도록 하는 기능 추가

### DIFF
--- a/src/main/java/com/sparta/instagramclonebe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/comment/controller/CommentController.java
@@ -12,19 +12,19 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/comment")
+@RequestMapping("/api")
 public class CommentController {
 
     private final CommentService commentService;
 
     //create
-    @PostMapping("/")
+    @PostMapping("/comment")
     public ResponseEntity<GlobalResponseDto<CommentResponseDto>> createComment(@RequestParam(value = "postId") Long postId, @RequestBody CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return commentService.createComment(postId, commentRequestDto, userDetails.getUser());
     }
 
     //delete
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/comment/{id}")
     public ResponseEntity<GlobalResponseDto<Void>> deleteComment(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return commentService.deleteComment(id, userDetails.getUser());
     }

--- a/src/main/java/com/sparta/instagramclonebe/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/comment/dto/CommentRequestDto.java
@@ -2,10 +2,12 @@ package com.sparta.instagramclonebe.domain.comment.dto;
 
 import lombok.Getter;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Getter
 public class CommentRequestDto {
+    @NotNull
     @Size(min = 1, max = 300, message = "댓글은 1글자 이상 300글자 이하로만 작성할 수 있습니다.")
     private String content;
 }

--- a/src/main/java/com/sparta/instagramclonebe/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/comment/dto/CommentResponseDto.java
@@ -11,15 +11,25 @@ public class CommentResponseDto {
     private Long id;
     private String content;
     private LocalDateTime createdAt;
+    private Long commentLikeCount;
     @Builder
-    private CommentResponseDto(Comment comment){
+    private CommentResponseDto(Comment comment, Long commentLikeCount){
         this.content = comment.getContent();
         this.createdAt = comment.getCreatedAt();
         this.id = comment.getId();
+        this.commentLikeCount = commentLikeCount;
     }
     public static CommentResponseDto of(Comment comment){
         return CommentResponseDto.builder()
                 .comment(comment)
+                .commentLikeCount(0L)
+                .build();
+    }
+
+    public static CommentResponseDto of(Comment comment, Long commentLikeCount){
+        return CommentResponseDto.builder()
+                .comment(comment)
+                .commentLikeCount(commentLikeCount)
                 .build();
     }
 }

--- a/src/main/java/com/sparta/instagramclonebe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package com.sparta.instagramclonebe.domain.comment.repository;
 
 import com.sparta.instagramclonebe.domain.comment.entity.Comment;
+import com.sparta.instagramclonebe.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByPost(Post post);
 }

--- a/src/main/java/com/sparta/instagramclonebe/domain/like/entity/CommentLike.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/like/entity/CommentLike.java
@@ -1,7 +1,6 @@
 package com.sparta.instagramclonebe.domain.like.entity;
 
 import com.sparta.instagramclonebe.domain.comment.entity.Comment;
-import com.sparta.instagramclonebe.domain.post.entity.Post;
 import com.sparta.instagramclonebe.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +9,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Getter
-@Entity
+@Entity(name = "commentLike")
 @NoArgsConstructor
 public class CommentLike {
     @Id

--- a/src/main/java/com/sparta/instagramclonebe/domain/like/entity/PostLike.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/like/entity/PostLike.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Getter
-@Entity
+@Entity(name = "postLike")
 @NoArgsConstructor
 public class PostLike {
     @Id

--- a/src/main/java/com/sparta/instagramclonebe/domain/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/like/repository/CommentLikeRepository.java
@@ -1,13 +1,14 @@
 package com.sparta.instagramclonebe.domain.like.repository;
 
+import com.sparta.instagramclonebe.domain.comment.entity.Comment;
 import com.sparta.instagramclonebe.domain.like.entity.CommentLike;
-import com.sparta.instagramclonebe.domain.like.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
     Optional<CommentLike> findByCommentIdAndUserId(Long id, Long id1);
+    Long countByComment(Comment comment);
 
     void deleteByCommentIdAndUserId(Long id, Long id1);
 }

--- a/src/main/java/com/sparta/instagramclonebe/domain/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/like/repository/PostLikeRepository.java
@@ -7,9 +7,7 @@ import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike,Long> {
     Optional<PostLike> findByPostIdAndUserId(Long id, Long id1);
-
     void deleteByPostIdAndUserId(Long id, Long id1);
-
-    int countPostLikeByPostId(Long id);
+    Long countPostLikeByPostId(Long id);
 
 }

--- a/src/main/java/com/sparta/instagramclonebe/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/post/controller/PostController.java
@@ -14,25 +14,25 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/posts")
+@RequestMapping("/api")
 public class PostController {
 
     private final PostService postService;
 
     //게시글 작성
-    @PostMapping("/")
+    @PostMapping("/posts")
     public ResponseEntity<GlobalResponseDto<PostResponseDto>> createReview(@RequestBody PostRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return postService.createPost(requestDto, userDetails.getUser());
     }
 
     //게시글 전체 조회
-    @GetMapping("/")
+    @GetMapping("/posts")
     public ResponseEntity<GlobalResponseDto<List<PostResponseDto>>> getReviews() {
         return postService.getPosts();
     }
 
     // 게시글 상세 조회
-    @GetMapping("/{id}")
+    @GetMapping("/posts/{id}")
     public ResponseEntity<GlobalResponseDto<PostResponseDto>> getReview(@PathVariable Long id){
         return postService.getPost(id);
     }
@@ -50,13 +50,13 @@ public class PostController {
 //    }
 
     //게시글 수정
-    @PutMapping("/{id}")
+    @PutMapping("/posts/{id}")
     public ResponseEntity<GlobalResponseDto<PostResponseDto>> updatePost(@PathVariable Long id, @RequestBody PostRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return postService.update(id, requestDto, userDetails.getUser());
     }
 
     //게시글 삭제
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/posts/{id}")
     public ResponseEntity<GlobalResponseDto<Void>> deleteReview(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return postService.deletePost(id, userDetails.getUser());
     }

--- a/src/main/java/com/sparta/instagramclonebe/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/sparta/instagramclonebe/domain/post/dto/PostResponseDto.java
@@ -1,9 +1,13 @@
 package com.sparta.instagramclonebe.domain.post.dto;
 
+import com.sparta.instagramclonebe.domain.comment.dto.CommentResponseDto;
 import com.sparta.instagramclonebe.domain.post.entity.Post;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -12,14 +16,16 @@ public class PostResponseDto {
     private Long postId;
     private String content;
     private String imageUrl;
-    private int postLikeCount;
+    private Long postLikeCount;
+    private List<CommentResponseDto> commentList = new ArrayList<>();
 
     @Builder
-    private PostResponseDto(Post post,int postLikeCount){
+    private PostResponseDto(Post post, Long postLikeCount, List<CommentResponseDto> commentList){
         this.postId = post.getId();
         this.content = post.getContent();
         this.imageUrl = post.getImageUrl();
         this.postLikeCount = postLikeCount;
+        this.commentList = commentList;
     }
 
     public static PostResponseDto of(Post post){
@@ -27,10 +33,12 @@ public class PostResponseDto {
                 .post(post)
                 .build();
     }
-    public static PostResponseDto of(Post post, int postLikeCount){
+
+    public static PostResponseDto of(Post post, Long postLikeCount, List<CommentResponseDto> commentList){
         return PostResponseDto.builder()
                 .post(post)
                 .postLikeCount(postLikeCount)
+                .commentList(commentList)
                 .build();
     }
 }

--- a/src/main/java/com/sparta/instagramclonebe/global/excpetion/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/instagramclonebe/global/excpetion/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -54,12 +55,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<List<ObjectError>> handleMethodException(MethodArgumentNotValidException ex){
+    public ResponseEntity<List<String>> handleMethodException(MethodArgumentNotValidException ex){
         BindingResult bindingResult = ex.getBindingResult();
         List<ObjectError> allErrors = bindingResult.getAllErrors();
+        List<String> allMessages = new ArrayList<>();
         for (ObjectError error : allErrors) {
-            log.error("Error : " + error);
+            log.error(error.getDefaultMessage());
+            allMessages.add(error.getDefaultMessage());
         }
-        return new ResponseEntity<>(allErrors, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(allMessages, HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## 📕 게시글에 댓글 목록과 좋아요 숫자를 보이도록 하는 기능 추가

## 📗 작업 내용

- [x] 게시글에 댓글 목록 보이도록 하는 기능 추가
- [x] 게시글에 좋아요 숫자를 보이도록 하는 기능 추가
- [x] 게시글의 댓글마다 좋아요 숫자가 보이도록 하는 기능 추가
- [x] 댓글에 빈 칸을 적어도 댓글이 작성되던 오류 수정
- [x] 엔티티 이름이 지정되지 않아 테이블이 생성되지 않던 오류 수정
- [x] Post와 Comment 엔티티의 ReqeustMapping의 경로 수정
- [x] GlobalException이 에러 메세지가 아닌 에러를 출력하던 오류 수정

## 📘 PR 특이 사항
x